### PR TITLE
[WIP] シグナルの章の各例題実装

### DIFF
--- a/chapter10/10-10.rb
+++ b/chapter10/10-10.rb
@@ -1,0 +1,29 @@
+require 'ffi'
+
+class SigprocmaskError < SystemCallError; end
+
+class Sigset < FFI::Struct
+  layout :__val, :ulong
+end
+
+module SignalExt
+  extend FFI::Library
+  ffi_lib 'libc.so.6'
+  attach_function :sigprocmask, [:int, :pointer, :pointer], :int
+  attach_function :sigismember, [:pointer, :int], :int
+end
+
+
+def pr_mask str
+  sigset = Sigset.new
+  if SignalExt.sigprocmask(0, nil, sigset) < 0
+    raise SigprocmaskError
+  end
+
+  print str
+  print " INT"  if SignalExt.sigismember(sigset, Signal.list["INT"])
+  print " QUIT" if SignalExt.sigismember(sigset, Signal.list["QUIT"])
+  print " USR1" if SignalExt.sigismember(sigset, Signal.list["USR1"])
+  print " ALRM" if SignalExt.sigismember(sigset, Signal.list["ALRM"])
+  print "\n"
+end

--- a/chapter10/10-10.rb
+++ b/chapter10/10-10.rb
@@ -1,6 +1,6 @@
 require 'ffi'
 
-class SigprocmaskError < SystemCallError; end
+class SigprocmaskError < Exception; end
 
 class Sigset < FFI::Struct
   layout :__val, :ulong

--- a/chapter10/10-11.rb
+++ b/chapter10/10-11.rb
@@ -6,11 +6,10 @@ trap("QUIT") {
 }
 
 newmask = Signal::Sigset.new
-Signal.sigemptyset(newmask)
 Signal.sigaddset(newmask, Signal.list["QUIT"])
 
 oldmask = Signal::Sigset.new
-Signal.sigprocmask(Signl::SIG_BLOCK, newmask, oldmask)
+Signal.sigprocmask(Signal::SIG_BLOCK, newmask, oldmask)
 
 sleep 5
 

--- a/chapter10/10-11.rb
+++ b/chapter10/10-11.rb
@@ -1,0 +1,26 @@
+require './posixsignal'
+
+# can't reset SIGQUIT
+trap("QUIT") {
+  puts "caught SIGQUIT"
+}
+
+newmask = Signal::Sigset.new
+Signal.sigemptyset(newmask)
+Signal.sigaddset(newmask, Signal.list["QUIT"])
+
+oldmask = Signal::Sigset.new
+Signal.sigprocmask(Signl::SIG_BLOCK, newmask, oldmask)
+
+sleep 5
+
+pendmask = Signal::Sigset.new
+Signal.sigpending(pendmask)
+if Signal.sigismember(pendmask, Signal.list["QUIT"]) > 0
+  puts "\nSIGQUIT pending"
+end
+
+Signal.sigprocmask(Signal::SIG_SETMASK, oldmask, nil)
+puts "SIGQUIT unblocked"
+
+sleep 5

--- a/chapter10/10-2.rb
+++ b/chapter10/10-2.rb
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+require 'etc'
+require 'ffi'
+
+module Alarm
+  extend FFI::Library
+  ffi_lib 'libc.so.6'
+  attach_function :alarm, [:uint], :uint
+end
+
+Signal.trap(:SIGALRM) {|signo|
+  puts "in signal handler"
+  Etc.getpwnam("root")
+  Alarm.alarm(1)
+}
+Alarm.alarm(1)
+
+# シグナルハンドラは
+# シグナルを通知された時点で実行するのではなく通知後に
+# バイトコード実行中に実行される
+while true
+  rec = Etc.getpwnam("kubo39")
+  puts "return value corrupted!" if rec.name != "kubo39"
+end

--- a/chapter10/10-3.rb
+++ b/chapter10/10-3.rb
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+
+# シグナルハンドラを再設定する必要はない
+trap("SIGCLD") {
+  puts "SIGCLD received"
+  pid, status = Process.wait
+  puts "pid=#{pid}"
+}
+
+fork do
+  sleep 2
+  exit!
+end
+
+sleep 3 # waiting signal
+exit

--- a/chapter10/10-4.rb
+++ b/chapter10/10-4.rb
@@ -1,0 +1,21 @@
+require 'ffi'
+
+module Unistd
+  extend FFI::Library
+  ffi_lib 'libc.so.6'
+  attach_function :alarm, [:uint], :uint
+  attach_function :pause, [], :int
+end
+
+def sleep1 seconds
+  trap("ALRM"){|signo|
+    # nop
+  }
+  Unistd.alarm seconds
+  Unistd.pause
+  Unistd.alarm 0
+end
+
+if __FILE__ == $0
+  sleep1 2
+end

--- a/chapter10/10-7.rb
+++ b/chapter10/10-7.rb
@@ -1,0 +1,14 @@
+require 'ffi'
+
+module Unistd
+  extend FFI::Library
+  ffi_lib 'libc.so.6'
+  attach_function :alarm, [:uint], :uint
+end
+
+trap("ALRM") {}
+Unistd.alarm 10
+
+line = STDIN.readline
+Unistd.alarm 0
+puts line

--- a/chapter10/10-9.rb
+++ b/chapter10/10-9.rb
@@ -1,0 +1,28 @@
+NSIG = Signal.list.values.max + 1
+
+def SIGBAD signo
+  signo <= 0 || signo >= NSIG
+end
+
+def sigaddset(sigset, signo)
+  if SIGBAD(signo) > 0
+    raise Errno::EINVAL
+  end
+  sigset |= (1 << (signo - 1))
+  return 0
+end
+
+def sigdelset(sigset, signo)
+  if SIGBAD(signo) > 0
+    raise Errno::EINVAL
+  end
+  sigset &= ~(1 << (signo - 1))
+  return 0
+end
+
+def sigismember(set, signo)
+  if SIGBAD(signo) > 0
+    raise Errno::EINVAL
+  end
+  return set & (1 << (signo - 1) != 0)
+end

--- a/chapter10/posixsignal.rb
+++ b/chapter10/posixsignal.rb
@@ -1,0 +1,71 @@
+require 'ffi'
+
+
+SIG_BLOCK = 0
+SIG_UNBLOCK = 1
+SIG_SETMASK = 2
+
+module Unistd
+  extend FFI::Library
+  ffi_lib 'libc.so.6'
+
+  # unsigned int alarm(unsigned int);
+  attach_function :alarm, [:uint], :uint
+
+  # int pause(void);
+  attach_function :pause, [:void], :int
+end
+
+
+module SignalExt
+  extend FFI::Library
+  ffi_lib 'libc.so.6'
+
+  class Sigset < FFI::Struct
+    layout :__val, :ulong
+  end
+
+  # int sigprocmask(int, const sigset_t*, const sigset_t*);
+  attach_function :sigprocmask, [:int, :pointer, :pointer], :int
+
+  # int sigismember(const sigset_t*, int);
+  attach_function :sigismember, [:pointer, :int], :int
+
+  # int sigemptyset(sigset_t*);
+  attach_function :sigemptyset, [:pointer], :int
+
+  # int sigaddset(sigset_t*, int);
+  attach_function :sigaddset, [:pointer, :int], :int
+
+  # int sigpending(sigset_t*);
+  attach_function :sigpending, [:pointer], :int
+end
+
+
+module Signal
+  class SigprocmaskError < Exception; end
+
+  Sigset = SignalExt::Sigset
+
+  def self.sigprocmask(how, set, oldset)
+    if SignalExt.sigprocmask(how, set, oldset) < 0
+      raise SigprocmaskError
+    end
+  end
+
+  def self.sigismember(set, signo)
+    SignalExt.sigismember(set, signo)
+  end
+
+  def self.sigemptyset(set)
+    SignalExt.sigemptyset(set)
+  end
+
+  def self.sigaddset(set, signo)
+    SignalExt.sigaddset(set, signo)
+  end
+
+  def self.sigpending(set)
+    SignalExt.sigpending(set)
+  end
+end

--- a/chapter10/posixsignal.rb
+++ b/chapter10/posixsignal.rb
@@ -44,13 +44,15 @@ module Signal
   SIG_SETMASK = 2
 
   class SigprocmaskError < Exception; end
+  class SigpendingError < Exception; end
 
   Sigset = SignalExt::Sigset
 
   def self.sigprocmask(how, set, oldset)
-    if SignalExt.sigprocmask(how, set, oldset) < 0
+    if SignalExt.sigprocmask(how, set, oldset) != 0
       raise SigprocmaskError
     end
+    return 0
   end
 
   def self.sigismember(set, signo)
@@ -66,6 +68,9 @@ module Signal
   end
 
   def self.sigpending(set)
-    SignalExt.sigpending(set)
+    if SignalExt.sigpending(set) != 0
+      raise SigpendingError
+    end
+    return 0
   end
 end

--- a/chapter10/posixsignal.rb
+++ b/chapter10/posixsignal.rb
@@ -1,10 +1,6 @@
 require 'ffi'
 
 
-SIG_BLOCK = 0
-SIG_UNBLOCK = 1
-SIG_SETMASK = 2
-
 module Unistd
   extend FFI::Library
   ffi_lib 'libc.so.6'
@@ -43,6 +39,10 @@ end
 
 
 module Signal
+  SIG_BLOCK = 0
+  SIG_UNBLOCK = 1
+  SIG_SETMASK = 2
+
   class SigprocmaskError < Exception; end
 
   Sigset = SignalExt::Sigset


### PR DESCRIPTION
一部Rubyの標準機能だけでは実装が困難であるところはFFI gemを用いて実装した。
それでも実装が大変なところ(setjmp/longjmp)は実装を見送った。

基本的には各コミットログに例題の詳細を書いているが、一部RubyとC実装で扱いが異なる部分に関する説明を追記する。
- Rubyではシグナルを受けたタイミングで即座にシグナルハンドラが実行されるわけではない。
- シグナルハンドラの再設定は不要。
